### PR TITLE
Handle string and symbol keys both for args option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+Now we support string and symbol keys in the `args` option.
+
 # 0.2.0
 
 Updated [byebug](https://github.com/deivid-rodriguez/byebug) version to 11.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quandora (0.1.0)
+    quandora (0.3.0)
       faraday (~> 2.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ the args it must be:
   "content": "content"
 }
 
-udpate: Quandora.bases.tag('base_id').udpate(args)
+update: Quandora.bases.tag('base_id').update(args)
 the args it must be:
 {
   "uid": "uid",

--- a/lib/quandora.rb
+++ b/lib/quandora.rb
@@ -40,6 +40,7 @@ module Quandora
           conn.set_basic_auth(configuration.username, configuration.password)
         end
 
+        args = args.stringify_keys
         find_api(api).new(@conn, api, args)
       end
     end

--- a/lib/quandora/activity.rb
+++ b/lib/quandora/activity.rb
@@ -2,6 +2,8 @@
 
 class Quandora::Activity < Quandora::Request
   def index(args = {})
+    args = args.stringify_keys
+
     @params.merge!("userId": args["user_id"]) unless args.fetch('user_id', nil).nil?
     super
   end

--- a/lib/quandora/answer.rb
+++ b/lib/quandora/answer.rb
@@ -1,5 +1,7 @@
 class Quandora::Answer < Quandora::Request
   def vote(answer_id, args)
+    args = args.stringify_keys
+
     body = {
       "type": "boolean",
       "data": args["vote"]
@@ -12,6 +14,8 @@ class Quandora::Answer < Quandora::Request
   end
 
   def accept(answer_id, args)
+    args = args.stringify_keys
+
     body = {
       "type": "boolean",
       "data": args["accept"]
@@ -24,6 +28,6 @@ class Quandora::Answer < Quandora::Request
   end
 
   def comment(answer_id)
-    Comment.new(@conn, "a", answer_id)    
+    Comment.new(@conn, "a", answer_id)
   end
 end

--- a/lib/quandora/bases.rb
+++ b/lib/quandora/bases.rb
@@ -5,6 +5,8 @@ class Quandora::Bases < Quandora::Request
   end
 
   def questions(base_id, args = {})
+    args = args.stringify_keys
+
     @api = "kb/#{base_id}/list"
     @params.merge!("o": args["o"]) unless args.fetch('o', nil).nil?
     @params.merge!("l": args["l"]) unless args.fetch('l', nil).nil?
@@ -15,12 +17,16 @@ class Quandora::Bases < Quandora::Request
   end
 
   def mlt(base_id, args = {})
+    args = args.stringify_keys
+
     @api = "kb/#{base_id}/mlt"
     @params.merge!("q": args["q"]) unless args.fetch('q', nil).nil?
     index
   end
 
   def ask(base_id, args = {})
+    args = args.stringify_keys
+
     body = {
       "type": "post-question",
       "data": {
@@ -42,10 +48,10 @@ class Quandora::Bases < Quandora::Request
   end
 
   def tag(kb_id)
-    Quandora::Tag.new(@conn, "kb", kb_id)    
+    Quandora::Tag.new(@conn, "kb", kb_id)
   end
 
   def report(kb_id)
-    Quandora::Report.new(@conn, "kb", kb_id)    
+    Quandora::Report.new(@conn, "kb", kb_id)
   end
 end

--- a/lib/quandora/comment.rb
+++ b/lib/quandora/comment.rb
@@ -6,6 +6,8 @@ class Quandora::Comment
   end
 
   def create(args)
+    args = args.stringify_keys
+
     body = {
       "type": "post-comment",
       "data": {
@@ -20,6 +22,8 @@ class Quandora::Comment
   end
 
   def update(args)
+    args = args.stringify_keys
+
     body = {
       "type": "post-comment",
       "data": {

--- a/lib/quandora/end_points.rb
+++ b/lib/quandora/end_points.rb
@@ -1,5 +1,7 @@
 class Quandora::EndPoints < Quandora::Request
   def index(args = {})
+    args = args.stringify_keys
+
     @api = ""
     super
   end

--- a/lib/quandora/question.rb
+++ b/lib/quandora/question.rb
@@ -17,6 +17,8 @@ class Quandora::Question < Quandora::Request
   end
 
   def answer(question_id, args)
+    args = args.stringify_keys
+
     body = {
       "type": "post-answer",
       "data": {
@@ -31,6 +33,8 @@ class Quandora::Question < Quandora::Request
   end
 
   def vote(question_id, args)
+    args = args.stringify_keys
+
     body = {
       "type": "boolean",
       "data": args["vote"]
@@ -43,10 +47,10 @@ class Quandora::Question < Quandora::Request
   end
 
   def comment(question_id)
-    Quandora::Comment.new(@conn, "q", question_id)    
+    Quandora::Comment.new(@conn, "q", question_id)
   end
 
   def tag(answer_id)
-    Quandora::Tag.new(@conn, "q", answer_id)    
+    Quandora::Tag.new(@conn, "q", answer_id)
   end
 end

--- a/lib/quandora/request.rb
+++ b/lib/quandora/request.rb
@@ -8,6 +8,8 @@ class Quandora::Request
   end
 
   def index(args = {})
+    args = args.stringify_keys
+
     @params.merge!("o": args["o"]) unless args.fetch('o', nil).nil?
     @params.merge!("l": args["l"]) unless args.fetch('l', nil).nil?
 
@@ -18,6 +20,8 @@ class Quandora::Request
   end
 
   def show(id, args = {})
+    args = args.stringify_keys
+
     resp = @conn.get("#{@api}/#{id}") do |req|
       req.params = @params
       req.headers['Content-Type'] = 'application/json'

--- a/lib/quandora/tag.rb
+++ b/lib/quandora/tag.rb
@@ -6,6 +6,8 @@ class Quandora::Tag
   end
 
   def index(args={})
+    args = args.stringify_keys
+
     query = {}
     query.merge!("q": args["q"]) unless args.fetch('q', nil).nil?
     query.merge!("s": args["s"]) unless args.fetch('s', nil).nil?
@@ -23,14 +25,16 @@ class Quandora::Tag
   end
 
   def create(args)
+    args = args.stringify_keys
+
     body = {
       "type": "tag-content",
       "data": {
-        "name": args[:name],
+        "name": args['name'],
         "category": nil,
         "location": nil,
-        "url": args[:url],
-        "content": args[:content]
+        "url": args['url'],
+        "content": args['content']
       }
     }
 
@@ -41,6 +45,8 @@ class Quandora::Tag
   end
 
   def update(args)
+    args = args.stringify_keys
+
     body = {
       "type": "tag-content",
       "data": {

--- a/lib/quandora/users.rb
+++ b/lib/quandora/users.rb
@@ -5,6 +5,8 @@ class Quandora::Users < Quandora::Request
   end
 
   def create(args)
+    args = args.stringify_keys
+
     body = {
       "type": "post-user",
       "data": {

--- a/lib/quandora/version.rb
+++ b/lib/quandora/version.rb
@@ -1,3 +1,3 @@
 module Quandora
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Now we support string and symbol keys in the `args` option.
